### PR TITLE
Ignore some smells for migrations

### DIFF
--- a/config_files/.reek.yml
+++ b/config_files/.reek.yml
@@ -27,3 +27,12 @@ directories:
   "app/models":
     InstanceVariableAssumption:
       enabled: false
+  "db/migrate":
+    UncommunicativeVariableName:
+      enabled: false
+    FeatureEnvy:
+      enabled: false
+    TooManyStatements:
+      enabled: false
+    IrresponsibleModule:
+      enabled: false


### PR DESCRIPTION
**IMPORTANT: please be descriptive and provide all required information. Make sure you provide all the information needed for others to review your PR. On sections marked “if applicable”, if that section is not applicable make sure to delete it. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes.**

**What is this PR:**

- [ ] Bug fix
- [x] Feature
- [ ] Chore

**Description:**

Reek detects common migrations patterns as code smells, it shouldn't complain about newly created migrations created with the rails generators.

**Screenshots:**

![image](https://user-images.githubusercontent.com/188464/99667539-53191a80-2a4b-11eb-86a7-b2572f383541.png)

**Related story:**

https://www.pivotaltracker.com/story/show/175798472

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

Tried opening migration files in a project with and without that configuration so the code editor displays the smells. After adding that info, code editor shows no smells from reek.
