### PR TITLE
Remove references to RailsBestPractices linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ This file sets a few gems and tools, and configure them:
 - [rubocop (with standardrb config)](https://github.com/testdouble/standard)
 - [rubocop-ombu_labs](https://github.com/fastruby/rubocop-ombu_labs)
 - [reek](https://github.com/troessner/reek)
-- [rails_best_practices](https://github.com/flyerhzm/rails_best_practices)
 - [overcommit](https://github.com/sds/overcommit)
 - [StandardJS](https://github.com/standard/standard)
 

--- a/config_files/.overcommit.yml
+++ b/config_files/.overcommit.yml
@@ -36,9 +36,6 @@ PreCommit:
   Reek:
     enabled: true
 
-  RailsBestPractices:
-    enabled: true
-
   Standard:
     enabled: true
 

--- a/template.rb
+++ b/template.rb
@@ -49,7 +49,6 @@ gem_group :development, :test do
   gem "rubocop-rspec" # rspec rules for rubocop
   gem "rubocop-rails" # rails rules for rubocop
   gem "reek" # code smells linter
-  gem "rails_best_practices" # rails bad practices linter
   gem "overcommit", "0.57.0" # run linters when trying to commit
 end
 
@@ -204,7 +203,7 @@ end
 # add suggested reek config for Rails applications
 create_file ".reek.yml", get_gh_file_content(".reek.yml")
 
-# add config for Overcommit (set it to do a few checks and run standardrb, reek and rails_best_practices)
+# add config for Overcommit (set it to do a few checks and run standardrb and reek)
 create_file ".overcommit.yml", get_gh_file_content(".overcommit.yml")
 
 # add RuboCop config


### PR DESCRIPTION
**IMPORTANT: please be descriptive and provide all required information. Make sure you provide all the information needed for others to review your PR. On sections marked “if applicable”, if that section is not applicable make sure to delete it. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes.**

**What is this PR:**

- [ ] Bug fix
- [x] Feature
- [ ] Chore

**Description:**

RailsBestPractices linter is not giving useful results and it's even reporting standard controller actions like `index` or `create` as unused. It's not adding any value.

**Screenshots:**

![image](https://user-images.githubusercontent.com/188464/99669315-a3917780-2a4d-11eb-8a02-7a38a2aee334.png)

**Related story:**

https://www.pivotaltracker.com/story/show/175798654

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

Tried to do a commit without this configuration in a test project and verified overcommit is not showing info related to RailsBestPractices.
