### PR TITLE
Ignore errors if parsing binary files

### DIFF
--- a/config_files/branding_pre_commit_hook.rb
+++ b/config_files/branding_pre_commit_hook.rb
@@ -21,6 +21,8 @@ module Overcommit::Hook::PreCommit
         check(line, /omb.\s*labs/i, VALID_OMBULABS)
         check(line, /fastruby/i, VALID_FASTRUBY)
       end
+    rescue
+      # rescue exception if trying to parse binary files
     end
 
     def check(line, regxp, valid_list)


### PR DESCRIPTION
**What is this PR:**

- [x] Bug fix
- [ ] Feature
- [ ] Chore

**Description:**

The script tries to parse all modified files to check for invalid branding. When reading binary files (like images or videos) it fails due to invalid UTF-8 string. This PR adds a `rescue` clause to the method so it ignores errors like that.

**Related story:**

https://www.pivotaltracker.com/story/show/176027063

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

Tried copying one image to have something to commit and was able to reproduce the error. Then added the `rescue` clause and the error is gone.
