### PR TITLE
Ignore some rails files from branding hook

### DIFF
--- a/config_files/branding_pre_commit_hook.rb
+++ b/config_files/branding_pre_commit_hook.rb
@@ -5,6 +5,8 @@ module Overcommit::Hook::PreCommit
     VALID_OMBULABS = [/OmbuLabs/, /www\.ombulabs\.com/, /ombulabs\//, /ombulabs-styleguide/, /ombu_labs/, /github\.com\/ombulabs/]
     VALID_FASTRUBY = [/FastRuby\.io/, /https?:\/\/\S*fastruby\S*\.io/, /fastruby[\/:]/, /fastruby-io-styleguide/]
 
+    IGNORE_FILES = ["branding.rb", "schema.rb", "database.yml", ".env.sample", "circleci", "package.json", "app.json", "cable.yml"]
+
     def run
       applicable_files.each { |file| check_file(file) }
 
@@ -14,6 +16,8 @@ module Overcommit::Hook::PreCommit
     end
 
     def check_file(filepath)
+      return if IGNORE_FILES.any? { |ignored| filepath.include?(ignored) }
+
       @current_file = filepath
 
       File.foreach(filepath).with_index do |line, lineno|


### PR DESCRIPTION
**What is this PR:**

- [ ] Bug fix
- [x] Feature
- [ ] Chore

**Description:**

This PR adds a list of files to be ignored by the branding hook. The list includes some Rails files that may have `ombulabs` or `fastruby` in unexpected but valid ways.

**Related story:**

https://www.pivotaltracker.com/story/show/177318676

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

The code was tested for OmbuLabs.com and FastRuby.io (for those repos the ignored list if a bit different because it includes specific files for those projects)