### PR TITLE
Add dotenv validator

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -54,6 +54,8 @@ end
 
 # environment
 gem "dotenv-rails"
+gem "dotenv_validator"
+initializer '1_dotenv_validator.rb', "DotenvValidator.check!"
 
 # pagination
 gem "pagy", "~> 3.8"

--- a/template.rb
+++ b/template.rb
@@ -177,7 +177,7 @@ run "mv config/database.yml config/database.yml.sample"
 gsub_file "bin/setup", "# system('bin/yarn')", "system('bin/yarn')"
 
 # make bin/setup move sample files to new locations
-inject_into_file "bin/setup", after: "system('bin/yarn')\n" do <<-'RUBY'
+inject_into_file "bin/setup", after: %r{system!?.'bin/yarn'.?\n} do <<-'RUBY'
 
   # Install overcommit hooks
   system("overcommit --install")
@@ -199,6 +199,11 @@ inject_into_file "bin/setup", after: "system('bin/yarn')\n" do <<-'RUBY'
 
   # copy database.yml sample
   FileUtils.cp "config/database.yml.sample", "config/database.yml"
+
+  # copy .env.sample if the .env is missing
+  unless File.exist?(".env")
+    FileUtils.cp ".env.sample", ".env"
+  end
 RUBY
 end
 


### PR DESCRIPTION
**IMPORTANT: please be descriptive and provide all required information. Make sure you provide all the information needed for others to review your PR. On sections marked “if applicable”, if that section is not applicable make sure to delete it. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes.**

**What is this PR:**

- [x] Bug fix
- [x] Feature
- [ ] Chore

**Description:**

Added dontenv_validator and initializer as per the installation instructions over here: https://github.com/fastruby/dotenv_validator#installation

Modified bin/setup to copy .env.sample file.
Also had to adjust the regex that looks for the place to
add the script.

**Related story:**

https://ombulabs.atlassian.net/browse/DT-71

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

I ran rails new and provided local versions of the railsrc and template.rb
```
rails new test-app --rc=./rails-template/.railsrc -m ./rails-template/template.rb
```

Once the app was created I verified that the initializer is correct and the bin/setup script copied the .env.sample file.
I also confirmed that the gem was added to the Gemfile.

