### PR TITLE
Ignore `.env` file

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -227,6 +227,7 @@ create_file ".github/pull_request_template.md", get_gh_file_content("pull_reques
 
 # ignore some files for git
 append_file ".gitignore" do <<-'GIT'
+.env
 .nvmrc
 .node-version
 .ruby-version


### PR DESCRIPTION
**What is this PR:**

- [ ] Bug fix
- [ ] Feature
- [x] Chore

**Description:**

Ignore `.env` file.

**Related story:**

https://ombulabs.atlassian.net/browse/DT-102

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

I created a new rails application with the given template.
```
rails new test-app --rc=./rails-template/.railsrc -m ./rails-template/template.rb
```
Once the app was created, I verified that the `.env` was added to the `.gitignore` file.