### PR TITLE
DT 101: Add .env.sample file

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -200,12 +200,16 @@ inject_into_file "bin/setup", after: %r{system!?.'bin/yarn'.?\n} do <<-'RUBY'
   # copy database.yml sample
   FileUtils.cp "config/database.yml.sample", "config/database.yml"
 
-  # copy .env.sample if the .env is missing
-  unless File.exist?(".env")
-    FileUtils.cp ".env.sample", ".env"
+  # copy .env file
+  unless File.exist?(".env") 
+    puts "\n== Copying .env file"
+    FileUtils.cp ".env.sample", ".env" 
   end
 RUBY
 end
+
+# add a blank .env.sample file
+create_file ".env.sample"
 
 # add suggested reek config for Rails applications
 create_file ".reek.yml", get_gh_file_content(".reek.yml")


### PR DESCRIPTION

- [x] Bug fix
- [ ] Feature
- [x] Chore

**Description:**

Add a blank `.env.sample` file and copy it to `.env` during setup.

**Screenshots:**

If changes to the UI are made, please include screenshots of the before and after. 

**Related story:**
https://ombulabs.atlassian.net/browse/DT-101

**Related links (if applicable):**
https://github.com/fastruby/rails-template/issues/13
https://github.com/fastruby/rails-template/issues/16

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**
1. Create a new rails application with the given template i.e. `rails new test-app --rc=./rails-template/.railsrc -m ./rails-template/template.rb`
2. Check if `.env.sample` exists in the project folder.
3. Run `bin/setup` and check if `.env` file is generate from `.env.sample`

